### PR TITLE
重构 FPS 文件解析为本地解析

### DIFF
--- a/src/apis/problem.ts
+++ b/src/apis/problem.ts
@@ -179,20 +179,3 @@ export const getProblemHistoryApi = useDefineApi<
     url: "/problem/history",
     method: "get"
 })
-
-export const uploadFPSApi = useDefineApi<
-    {
-        headers: {
-            "Content-Type": "multipart/form-data"
-        },
-        data: FormData
-    },
-    {
-        problem: FpsProblemInfo
-        solutions: FpsSolution[]
-        testcases: FpsTestcase[]
-    }[]
->({
-    url: "/problem/fps",
-    method: "post"
-})

--- a/src/components.d.ts
+++ b/src/components.d.ts
@@ -58,6 +58,7 @@ declare module 'vue' {
     ElOption: typeof import('element-plus/es')['ElOption']
     ElPagination: typeof import('element-plus/es')['ElPagination']
     ElPopover: typeof import('element-plus/es')['ElPopover']
+    ElProgress: typeof import('element-plus/es')['ElProgress']
     ElRow: typeof import('element-plus/es')['ElRow']
     ElSelect: typeof import('element-plus/es')['ElSelect']
     ElSubMenu: typeof import('element-plus/es')['ElSubMenu']

--- a/src/types/Problem.ts
+++ b/src/types/Problem.ts
@@ -96,7 +96,6 @@ export interface ProblemHistory {
 }
 
 export interface FpsProblemInfo {
-    create_time: string;
     description: string;
     input: string;
     memory_limit: number;
@@ -105,7 +104,6 @@ export interface FpsProblemInfo {
     sample_output: string;
     time_limit: number;
     title: string;
-    update_time: string;
     [property: string]: any;
 }
 

--- a/src/utils/parseFps.ts
+++ b/src/utils/parseFps.ts
@@ -1,0 +1,184 @@
+import type { ProblemInfo, Solution, Testcase } from "@/types/Problem";
+import { langStore } from "@/stores/language";
+
+// 辅助函数：从父元素中获取指定标签的文本内容（去除空白）
+function getElementTextContent(parent: Element, tag: string): string | undefined {
+    const element = parent.querySelector(tag);
+    return element ? element.textContent?.trim() : undefined;
+}
+
+/**
+ * 解析传入的 FPS 格式 XML 字符串，并返回包含 ProblemInfo、Testcase、Solution 的对象
+ * @param xmlString XML 文件内容字符串
+ */
+export async function parseFpsXml(xmlString: string): Promise<{
+    version: string;
+    items: {
+        problem: ProblemInfo;
+        testcases: Testcase[];
+        solutions: Solution[];
+    }[];
+    generator?: { name: string; url?: string };
+    url?: string;
+}> {
+    const parser = new DOMParser();
+    const xmlDoc = parser.parseFromString(xmlString, "application/xml");
+    
+    // 检查解析错误
+    const parserError = xmlDoc.querySelector("parsererror");
+    if (parserError) {
+        throw new Error("XML解析错误：" + parserError.textContent);
+    }
+
+    const fpsEl = xmlDoc.documentElement;
+    if (fpsEl.tagName !== "fps") {
+        throw new Error("不是有效的FPS格式XML！");
+    }
+
+    // 解析 fps 属性
+    const version = fpsEl.getAttribute("version") || "";
+    const urlAttr = fpsEl.getAttribute("url") || undefined;
+    
+    // 解析 generator 节点
+    let generator;
+    const generatorEl = fpsEl.querySelector("generator");
+    if (generatorEl) {
+        const name = generatorEl.getAttribute("name") || "";
+        const genUrl = generatorEl.getAttribute("url") || undefined;
+        generator = { name, url: genUrl };
+    }
+
+    // 从 langStore 获取语言列表，用于匹配 solution 中的语言
+    const store = langStore();
+    const langRef = await store.getLanguages();
+    const languages = langRef.value;
+
+    // 辅助函数：根据 XML 中的语言字符串从 languages 中获取最接近的语言 id
+    function getClosestLanguageId(xmlLang: string): number {
+        if (!xmlLang) return 0;
+        const lowerXml = xmlLang.toLowerCase();
+        for (const lang of languages) {
+            if (lang.name.toLowerCase().includes(lowerXml)) {
+                return lang.id || 0;
+            }
+        }
+        return 0;
+    }
+
+
+    // 解析 <item> 节点数组
+    const itemEls = fpsEl.querySelectorAll("item");
+    const items: {
+        problem: ProblemInfo;
+        testcases: Testcase[];
+        solutions: Solution[];
+    }[] = [];
+
+    itemEls.forEach(itemEl => {
+        const title = getElementTextContent(itemEl, "title") || "";
+        const description = getElementTextContent(itemEl, "description") || "";
+        const inputStr = getElementTextContent(itemEl, "input") || "";
+        const outputStr = getElementTextContent(itemEl, "output") || "";
+        const sample_input = getElementTextContent(itemEl, "sample_input") || "";
+        const sample_output = getElementTextContent(itemEl, "sample_output") || "";
+        const hint = getElementTextContent(itemEl, "hint") || "";
+        
+        // 解析 time_limit 和 memory_limit 并转换为数字
+        let time_limit = 0;
+        const timeLimitEl = itemEl.querySelector("time_limit");
+        if (timeLimitEl) {
+            const data = timeLimitEl.textContent?.trim() || "0";
+            time_limit = Number(data);
+        }
+        
+        let memory_limit = 0;
+        const memoryLimitEl = itemEl.querySelector("memory_limit");
+        if (memoryLimitEl) {
+            const data = memoryLimitEl.textContent?.trim() || "0";
+            memory_limit = Number(data);
+        }
+        
+        const problem: ProblemInfo = {
+            title,
+            description,
+            input: inputStr,
+            output: outputStr,
+            sample_input,
+            sample_output,
+            hint,
+            time_limit,
+            memory_limit,
+            difficulty: 0,
+        };
+
+        // 解析测试用例
+        const testcases: Testcase[] = [];
+        const testInputEls = itemEl.querySelectorAll("test_input");
+        const testOutputEls = itemEl.querySelectorAll("test_output");
+        if (testInputEls.length > 0 && testInputEls.length === testOutputEls.length) {
+            testInputEls.forEach((el, index) => {
+                const ti = el.textContent?.trim() || "";
+                const to = testOutputEls[index].textContent?.trim() || "";
+                testcases.push({ test_input: ti, test_output: to });
+            });
+        }
+
+        // 解析题解
+        const solutions: Solution[] = [];
+        const solutionEls = itemEl.querySelectorAll("solution");
+        if (solutionEls.length > 0) {
+            solutionEls.forEach(solEl => {
+                const xmlLang = solEl.getAttribute("language") || "";
+                const code = solEl.textContent?.trim() || "";
+                const language_id = getClosestLanguageId(xmlLang);
+                solutions.push({
+                    language_id,
+                    source_code: code,
+                    problem_id: 0,
+                });
+            });
+        }
+
+
+        items.push({ problem, testcases, solutions });
+    });
+
+    return {
+        version,
+        items,
+        ...(generator ? { generator } : {}),
+        ...(urlAttr ? { url: urlAttr } : {})
+    };
+}
+
+/**
+ * 通过 FileReader 异步读取用户上传的 XML 文件，并解析为 FPS 对象（直接解析为 ProblemInfo、Testcase、Solution）
+ * @param file 上传的 XML 文件
+ */
+export function parseFpsFile(file: File): Promise<{
+    version: string;
+    items: {
+        problem: ProblemInfo;
+        testcases: Testcase[];
+        solutions: Solution[];
+    }[];
+    generator?: { name: string; url?: string };
+    url?: string;
+}> {
+    return new Promise((resolve, reject) => {
+        const reader = new FileReader();
+        reader.onload = async () => {
+            try {
+                const text = reader.result as string;
+                const fps = await parseFpsXml(text);
+                resolve(fps);
+            } catch (err) {
+                reject(err);
+            }
+        };
+        reader.onerror = (err) => {
+            reject(err);
+        };
+        reader.readAsText(file);
+    });
+} 


### PR DESCRIPTION
- 移除 uploadFPSApi，改为客户端解析 FPS 文件
- 新增 parseFpsXml 工具函数用于解析 FPS 文件
- 更新 FPSImport 组件，使用新的解析逻辑
- 调整 FpsProblemInfo 接口，移除不必要的字段
- 在 FPSImport.vue 中添加进度条组件，用于显示文件解析进度
- 修改 parseFps.ts 中的 parseFpsXml 函数，增加进度回调参数
- 实现进度更新逻辑，每处理一定项更新一次进度